### PR TITLE
Implement settings page with adjustable name display limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,88 @@
-# linkedin-tag-extension
+# LinkedIn Tag Helper
 
-To install dependencies:
+A Chrome Extension (Manifest V3) for quickly tagging multiple LinkedIn users in posts. Built with Bun and TypeScript.
+
+## Features
+
+- Quickly collect LinkedIn users while browsing
+- Insert multiple user tags into LinkedIn posts with one click
+- Persistent storage of collected users
+
+## Installation
+
+### Prerequisites
+
+- [Bun](https://bun.sh) v1.0+
+- Chrome or Chromium-based browser
+
+### Setup
 
 ```bash
+# Clone the repository
+git clone https://github.com/yourusername/linkedin-tag-extension.git
+cd linkedin-tag-extension
+
+# Install dependencies
 bun install
 ```
 
-To run:
+## Development
+
+### Build
 
 ```bash
-bun run index.ts
+# Build the extension to ./dist
+bun run build
+
+# Watch mode (rebuilds on file changes)
+bun run watch
 ```
 
-This project was created using `bun init` in bun v1.3.3. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+### Load in Chrome
+
+1. Open Chrome and navigate to `chrome://extensions`
+2. Enable "Developer mode" (toggle in top right)
+3. Click "Load unpacked"
+4. Select the `./dist` directory
+
+
+## Project Structure
+
+```
+src/
+  types.ts           # Shared TypeScript interfaces
+  content/           # Content script injected into LinkedIn pages
+  popup/             # Extension popup UI
+dist/                # Build output (gitignored)
+icons/               # Extension icons
+build.ts             # Bun build script
+manifest.json        # Chrome extension manifest v3
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/your-feature`
+3. Make your changes
+4. Run the build to ensure it compiles: `bun run build`
+5. Run tests: `bun test`
+6. Commit your changes: `git commit -m "Add your feature"`
+7. Push to your fork: `git push origin feature/your-feature`
+8. Open a Pull Request
+
+### Code Style
+
+- Use `import type` for type-only imports
+- Follow existing naming conventions (kebab-case files, PascalCase interfaces, camelCase functions)
+- Prefix CSS classes with `linkedin-tag-helper-*`
+- Use async/await for Chrome APIs
+
+## Tech Stack
+
+- **Runtime**: [Bun](https://bun.sh)
+- **Language**: TypeScript (strict mode)
+- **Platform**: Chrome Extension Manifest V3
+
+## License
+
+MIT

--- a/src/content/content.css
+++ b/src/content/content.css
@@ -86,6 +86,13 @@
   border-bottom: 1px solid #f0f0f0;
 }
 
+.linkedin-tag-helper-dropdown-loading {
+  padding: 12px 14px;
+  font-size: 13px;
+  color: #666;
+  text-align: center;
+}
+
 /* Toast Notification */
 .linkedin-tag-helper-toast {
   position: fixed;
@@ -143,31 +150,13 @@
   z-index: 100;
 }
 
-.linkedin-tag-helper-editor-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: #666;
-  background-color: transparent;
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.linkedin-tag-helper-editor-btn:hover {
-  background-color: rgba(0, 0, 0, 0.08);
-  color: #191919;
+/* Only override what's necessary - let LinkedIn's artdeco classes handle the rest */
+.linkedin-tag-helper-editor-btn.artdeco-button {
+  /* Ensure our button matches LinkedIn's styling */
 }
 
 .linkedin-tag-helper-editor-btn svg {
-  flex-shrink: 0;
+  fill: currentColor;
 }
 
 .linkedin-tag-helper-editor-btn-text,
@@ -180,7 +169,7 @@
   display: none;
   position: absolute;
   bottom: 100%;
-  left: 100%;
+  left: 0;
   margin-bottom: 4px;
   width: 220px;
   background-color: #fff;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -35,6 +35,12 @@ header {
   gap: 8px;
 }
 
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 header h1 {
   font-size: 16px;
   font-weight: 600;
@@ -478,6 +484,124 @@ main {
 
 .form-actions .btn {
   flex: 1;
+}
+
+/* Settings Page */
+.settings-page {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #fff;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-page.hidden {
+  display: none;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.settings-header h1 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #191919;
+  flex: 1;
+}
+
+.save-indicator {
+  font-size: 12px;
+  color: #057642;
+  font-weight: 500;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+.save-indicator.hidden {
+  opacity: 0;
+}
+
+.settings-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.setting-category {
+  margin-bottom: 24px;
+}
+
+.setting-category-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #191919;
+  margin-bottom: 4px;
+}
+
+.setting-category-description {
+  font-size: 11px;
+  color: #666;
+  margin-bottom: 12px;
+}
+
+.setting-divider {
+  height: 1px;
+  background-color: #e0e0e0;
+  margin-bottom: 16px;
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+  gap: 16px;
+}
+
+.setting-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.setting-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #191919;
+  margin-bottom: 2px;
+}
+
+.setting-description {
+  font-size: 11px;
+  color: #666;
+  line-height: 1.4;
+}
+
+.setting-control {
+  flex-shrink: 0;
+}
+
+.setting-control input[type="number"] {
+  width: 60px;
+  padding: 6px 8px;
+  font-size: 13px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  outline: none;
+  text-align: center;
+  transition: border-color 0.15s ease;
+}
+
+.setting-control input[type="number"]:focus {
+  border-color: #0a66c2;
 }
 
 /* Footer */

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -604,6 +604,13 @@ main {
   border-color: #0a66c2;
 }
 
+.setting-control input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #0a66c2;
+}
+
 /* Footer */
 footer {
   display: flex;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -13,12 +13,20 @@
         <h1>Tag List</h1>
         <span id="count" class="count">0</span>
       </div>
-      <button id="manage-lists-btn" class="icon-btn" title="Manage lists">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="12" cy="12" r="3"></circle>
-          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-        </svg>
-      </button>
+      <div class="header-right">
+        <button id="manage-lists-btn" class="icon-btn" title="Manage lists">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+          </svg>
+        </button>
+        <button id="settings-btn" class="icon-btn" title="Settings">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="3"></circle>
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+          </svg>
+        </button>
+      </div>
     </header>
 
     <!-- List Selector -->
@@ -126,6 +134,24 @@
       <button id="insert-btn" class="btn btn-primary" disabled>Insert Tags</button>
       <button id="clear-btn" class="btn btn-secondary">Clear List</button>
     </footer>
+  </div>
+
+  <!-- Settings Page -->
+  <div id="settings-page" class="settings-page hidden">
+    <header class="settings-header">
+      <button id="back-btn" class="icon-btn">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="19" y1="12" x2="5" y2="12"></line>
+          <polyline points="12 19 5 12 12 5"></polyline>
+        </svg>
+      </button>
+      <h1>Settings</h1>
+      <span id="settings-save-indicator" class="save-indicator hidden">Saved</span>
+    </header>
+
+    <div id="settings-content" class="settings-content">
+      <!-- Populated dynamically from settings-config.ts -->
+    </div>
   </div>
 
   <script src="popup.js"></script>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,14 +1,10 @@
-import type { LinkedInUser, LinkedInOrg, LinkedInEntity, InsertTagsMessage, TagList, StorageData, Settings } from "../types";
+import type { LinkedInUser, LinkedInEntity, InsertTagsMessage, TagList, StorageData, Settings } from "../types";
 import { DEFAULT_LIST_ID, DEFAULT_SETTINGS } from "../types";
 import { SETTINGS_CONFIG } from "./settings-config";
 
 // Type guard functions
 function isLinkedInUser(entity: LinkedInEntity): entity is LinkedInUser {
   return entity.type === "user";
-}
-
-function isLinkedInOrg(entity: LinkedInEntity): entity is LinkedInOrg {
-  return entity.type === "org";
 }
 
 // Get entity unique identifier for comparison

--- a/src/popup/settings-config.ts
+++ b/src/popup/settings-config.ts
@@ -34,6 +34,13 @@ export const SETTINGS_CONFIG: SettingCategory[] = [
         step: 1,
         placeholder: "0",
       },
+      {
+        id: "truncateOrgNames",
+        name: "Truncate Organization Names",
+        description: "Apply word limit to organization/company names",
+        type: "toggle",
+        defaultValue: false,
+      },
     ],
   },
   // Future categories can be added here easily

--- a/src/popup/settings-config.ts
+++ b/src/popup/settings-config.ts
@@ -1,0 +1,40 @@
+export interface SettingOption {
+  id: string;
+  name: string;
+  description: string;
+  type: "number" | "toggle" | "select" | "text";
+  defaultValue: any;
+  min?: number;
+  max?: number;
+  step?: number;
+  placeholder?: string;
+  options?: Array<{ value: any; label: string }>;
+}
+
+export interface SettingCategory {
+  id: string;
+  title: string;
+  description?: string;
+  settings: SettingOption[];
+}
+
+export const SETTINGS_CONFIG: SettingCategory[] = [
+  {
+    id: "display",
+    title: "Display Settings",
+    description: "Customize how tags appear in your posts",
+    settings: [
+      {
+        id: "nameWordLimit",
+        name: "Name Display Limit",
+        description: "0 = Full name, 1 = First word only, 2+ = Number of words",
+        type: "number",
+        defaultValue: 0,
+        min: 0,
+        step: 1,
+        placeholder: "0",
+      },
+    ],
+  },
+  // Future categories can be added here easily
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,12 @@ export type LinkedInEntity = LinkedInUser | LinkedInOrg;
 // Global settings
 export interface Settings {
   nameWordLimit: number; // 0 = no limit (full name), 1+ = number of words to show
+  truncateOrgNames: boolean; // Apply word limit to organizations
 }
 
 export const DEFAULT_SETTINGS: Settings = {
   nameWordLimit: 0, // Full name by default
+  truncateOrgNames: false, // Don't truncate org names by default
 };
 
 export interface TagList {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,15 @@ export interface LinkedInOrg {
 
 export type LinkedInEntity = LinkedInUser | LinkedInOrg;
 
+// Global settings
+export interface Settings {
+  nameWordLimit: number; // 0 = no limit (full name), 1+ = number of words to show
+}
+
+export const DEFAULT_SETTINGS: Settings = {
+  nameWordLimit: 0, // Full name by default
+};
+
 export interface TagList {
   id: string;
   name: string;
@@ -27,6 +36,7 @@ export const DEFAULT_LIST_ID = "default";
 export interface StorageData {
   lists: TagList[];
   selectedListId: string;
+  settings?: Settings; // Global settings
 }
 
 // Legacy storage format for migration


### PR DESCRIPTION
## Description
This PR adds a global settings system to the extension, allowing users to control how user and organization names are displayed in LinkedIn tags. It introduces a popup settings page to define a word limit, stores preferences in Chrome local storage, and applies them when generating tags. The system is modular and ready for future settings.

Closes #1 

## Captures
<img width="389" height="363" alt="image" src="https://github.com/user-attachments/assets/32105829-6d3a-4996-a04a-5a60b1224bd2" />
<img width="389" height="363" alt="image" src="https://github.com/user-attachments/assets/39f276b9-eb2c-43f2-9f8c-2433666d82e9" />
